### PR TITLE
Use for-loop to tokenize args

### DIFF
--- a/rr_impl.bat
+++ b/rr_impl.bat
@@ -11,6 +11,13 @@ for /f "tokens=1* delims= " %%A in ("%*") do (
     set OPTIONS=%%B
 )
 
+:: Check for missing args
+if not defined COMMAND (
+    echo Root Resolve
+    echo Usage: rr ^<command^> [options]
+    exit /b 1
+)
+
 :: Locate the root file
 call :FindRootFilePath
 if not defined ROOT_FILE_PATH (

--- a/rr_impl.bat
+++ b/rr_impl.bat
@@ -3,23 +3,13 @@
 setlocal
 setlocal enabledelayedexpansion
 
-:: Isolate the command
-set COMMAND=%1
-if not defined COMMAND (
-    echo Root Resolve
-    echo Usage: rr ^<command^> [options]
-    exit /b 1
+:: We use the for-loop to tokenize the args in a way to preserve the
+:: string contents of the args. 'Standard' arg syntax will remove
+:: certain delimiter characters inside args (e.g. '=').
+for /f "tokens=1* delims= " %%A in ("%*") do (
+    set COMMAND=%%A
+    set OPTIONS=%%B
 )
-
-:: Gather options by shifting them all left one place
-set OPTIONS=%2
-shift
-:GatherOption
-    if [%2] == [] goto :NoMoreOptions
-    set OPTIONS=%OPTIONS% %2
-    shift
-    goto GatherOption
-:NoMoreOptions
 
 :: Locate the root file
 call :FindRootFilePath


### PR DESCRIPTION
Instead of `shift` + `%1 %2`, we use the `for /f` to tokenize the args. This better preserves the original string contents. `%1 %2` can accidentally splinter certain argument strings if they contain delimiters INSIDE the arg.